### PR TITLE
05-01 koajs chat app, fixes

### DIFF
--- a/05-koajs/01-chat-app/app.js
+++ b/05-koajs/01-chat-app/app.js
@@ -8,13 +8,13 @@ app.use(require('koa-bodyparser')());
 const Router = require('koa-router');
 const router = new Router();
 
-app.context.subscriberContexts = [];
+app.context.subscriberContexts = new Set();
 
 //
 // GET /subscribe
 
 const addSubscriber = (ctx, next) => {
-    ctx.subscriberContexts.push({ ctx, next });
+    ctx.subscriberContexts.add({ ctx, next });
 
     return next();
 }
@@ -61,7 +61,7 @@ const sendMessage = (ctx, next) => {
 }
 
 const clearSubscriberContexts = (ctx, next) => {
-    ctx.subscribes = [];
+    ctx.subscriberContexts.clear();
 
     return next();
 }

--- a/05-koajs/01-chat-app/app.js
+++ b/05-koajs/01-chat-app/app.js
@@ -59,7 +59,7 @@ const clearSubscriberContexts = (ctx, next) => {
 }
 
 const endResponse = (ctx, next) => {
-    // an empty response body
+    // set an empty response body
     ctx.body = null;
 
     return next();

--- a/05-koajs/01-chat-app/app.js
+++ b/05-koajs/01-chat-app/app.js
@@ -30,7 +30,8 @@ router.get('/subscribe', processSubscriber);
 const parseMessageData = (ctx, next) => {
     const requestBody = ctx.request.body;
 
-    if (!requestBody.hasOwnProperty('message')) {
+    if (!requestBody.hasOwnProperty('message')
+        || !requestBody.message) {
         return;
     }
 

--- a/05-koajs/01-chat-app/app.js
+++ b/05-koajs/01-chat-app/app.js
@@ -14,7 +14,19 @@ app.context.subscriberResolves = new Set();
 // GET /subscribe
 
 const processSubscriber = async (ctx, next) => {
-    const message = await new Promise(resolve => { ctx.subscriberResolves.add(resolve); });
+
+    const message = await new Promise(resolve => {
+        ctx.subscriberResolves.add(resolve);
+
+        // use nodejs `res` (response) object to process close connection.
+        // do not confuse the nodejs object with the koajs `response` object
+        ctx.res.on('close', () => {
+            // remove the subscriber if connection is closed
+            ctx.subscriberResolves.delete(resolve);
+
+            resolve();
+        });
+    });
 
     ctx.body = message;
 


### PR DESCRIPTION
@tadjik1 
* всё-таки без `timeout` правильнее. 
На `index.html` пропадают  постоянные переподключения и перестают переодически теряться сообщения;

* также заменил массив с подписчиками на коллекцию.
Обнаружил, что присвоение пустого массива в переменную `ctx.subscribes = [];` не обнуляет подписчиков в `clearSubscriberContexts`. Они по-прежнему доступны в `addSubscriber`.